### PR TITLE
Fix/ping health route

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,7 @@ pipeline {
           colourText("info","Checking deployed app health...")
           colourText("info","Pinging ${env.APP_URL}/api/health...")
           APP_STATUS = sh (
-            script: "curl -sL -w '%{http_code}' '${env.APP_URL}/api/health' -o /dev/null",
+            script: "curl --insecure -sL -w '%{http_code}' '${env.APP_URL}/api/health' -o /dev/null",
             returnStdout: true
           ).trim()
           colourText("info", "APP_STATUS: ${APP_STATUS}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,6 +207,7 @@ pipeline {
         script {
           colourText("info","Checking deployed app health...")
           colourText("info","Pinging ${env.APP_URL}/api/health...")
+          // We use --insecure to ignore certificate issues
           APP_STATUS = sh (
             script: "curl --insecure -sL -w '%{http_code}' '${env.APP_URL}/api/health' -o /dev/null",
             returnStdout: true


### PR DESCRIPTION
- Fixed the last stage of the `Jenkinsfile` where `curl` is used to ping the `/api/health` route of the node server, added `--insecure` flag