### PR TITLE
Fix/fetch promise refactor

### DIFF
--- a/src/actions/ApiActions.js
+++ b/src/actions/ApiActions.js
@@ -30,7 +30,7 @@ export function search(query, formQuery, jsonKey) {
       }
     }).catch(msg => {
       dispatch(sendingRequest(SENDING_SEARCH_REQUEST, false, jsonKey));
-      dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, msg, jsonKey));
+      dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, msg.toString(), jsonKey));
     });
   };
 }

--- a/src/actions/ApiActions.js
+++ b/src/actions/ApiActions.js
@@ -1,5 +1,5 @@
-import { SET_RESULTS, SET_FORMATTED_QUERY, SET_SEARCH_ERROR_MESSAGE, SENDING_SEARCH_REQUEST, SET_QUERY, SET_HEADERS } from '../constants/ApiConstants';
-import accessAPI from '../utils/accessAPI';
+import { SET_RESULTS, SET_FORMATTED_QUERY, SET_SEARCH_ERROR_MESSAGE, SENDING_SEARCH_REQUEST, SET_QUERY } from '../constants/ApiConstants';
+import { accessAPINew } from '../utils/accessAPI';
 import config from '../config/api-urls';
 
 const { REROUTE_URL, API_VERSION } = config;
@@ -14,28 +14,21 @@ export function search(query, formQuery, jsonKey) {
     const formattedQuery = formQuery(query);
     dispatch(setFormattedQuery(SET_FORMATTED_QUERY, formattedQuery, jsonKey));
 
-    accessAPI(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
+    accessAPINew(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
       method: 'GET',
       endpoint: `${API_VERSION}/${formattedQuery}`,
-    }), (success, data) => {
+    })).then(json => {
       dispatch(sendingRequest(SENDING_SEARCH_REQUEST, false, jsonKey));
-      if (success) {
-        // This is a workaround for the API returning 200 {} for no results, should be 404
-        if (Object.keys(data.json).length === 0 && data.json.constructor === Object) {
-          dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, '404: No results found.', jsonKey));
-        } else {
-          if (jsonKey === 'ubrn') {
-            // Wrap the results in an array as we only get {} from the API
-            dispatch(setResults(SET_RESULTS, [data.json], jsonKey));
-          } else {
-            dispatch(setResults(SET_RESULTS, data.json, jsonKey));
-          }
-          dispatch(setHeaders(SET_HEADERS, data.response, jsonKey));
-        }
+      // This is a workaround for the API returning 200 {} for no results, should be 404
+      if (Object.keys(json).length === 0 && json.constructor === Object) {
+        dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, '404: No results found.', jsonKey));
+      } else if (jsonKey === 'ubrn') {
+        // Wrap the results in an array as we only get {} from the API
+        dispatch(setResults(SET_RESULTS, [json], jsonKey));
       } else {
-        dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, data.message, jsonKey));
+        dispatch(setResults(SET_RESULTS, json, jsonKey));
       }
-    });
+    }).catch(msg => dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, msg, jsonKey)));
   };
 }
 
@@ -49,10 +42,6 @@ export function setQuery(type, query, jsonKey) {
 
 function setFormattedQuery(type, query, jsonKey) {
   return { type, query, jsonKey };
-}
-
-function setHeaders(type, headers, jsonKey) {
-  return { type, headers, jsonKey };
 }
 
 function sendingRequest(type, sending, jsonKey) {

--- a/src/actions/ApiActions.js
+++ b/src/actions/ApiActions.js
@@ -28,7 +28,10 @@ export function search(query, formQuery, jsonKey) {
       } else {
         dispatch(setResults(SET_RESULTS, json, jsonKey));
       }
-    }).catch(msg => dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, msg, jsonKey)));
+    }).catch(msg => {
+      dispatch(sendingRequest(SENDING_SEARCH_REQUEST, false, jsonKey));
+      dispatch(setErrorMessage(SET_SEARCH_ERROR_MESSAGE, msg, jsonKey));
+    });
   };
 }
 

--- a/src/actions/ApiActions.js
+++ b/src/actions/ApiActions.js
@@ -1,5 +1,5 @@
 import { SET_RESULTS, SET_FORMATTED_QUERY, SET_SEARCH_ERROR_MESSAGE, SENDING_SEARCH_REQUEST, SET_QUERY } from '../constants/ApiConstants';
-import { accessAPINew } from '../utils/accessAPI';
+import accessAPI from '../utils/accessAPI';
 import config from '../config/api-urls';
 
 const { REROUTE_URL, API_VERSION } = config;
@@ -14,7 +14,7 @@ export function search(query, formQuery, jsonKey) {
     const formattedQuery = formQuery(query);
     dispatch(setFormattedQuery(SET_FORMATTED_QUERY, formattedQuery, jsonKey));
 
-    accessAPINew(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
+    accessAPI(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
       method: 'GET',
       endpoint: `${API_VERSION}/${formattedQuery}`,
     })).then(json => {

--- a/src/actions/InfoActions.js
+++ b/src/actions/InfoActions.js
@@ -1,5 +1,5 @@
 import { SET_UI_INFO, SET_API_INFO, SENDING_UI_REQUEST, SENDING_API_REQUEST, SET_UI_ERROR_MESSAGE, SET_API_ERROR_MESSAGE } from '../constants/InfoConstants';
-import accessAPI from '../utils/accessAPI';
+import { accessAPINew } from '../utils/accessAPI';
 import config from '../config/api-urls';
 
 const { AUTH_URL, REROUTE_URL } = config;
@@ -11,16 +11,16 @@ export function getUiInfo() {
   return (dispatch) => {
     dispatch(sendingRequest(SENDING_UI_REQUEST, true));
 
-    accessAPI(`${AUTH_URL}/api/info`, 'GET', sessionStorage.accessToken, {}, (success, data) => {
+    accessAPINew(`${AUTH_URL}/api/info`, 'GET', sessionStorage.accessToken, {})
+    .then(json => {
       dispatch(sendingRequest(SENDING_UI_REQUEST, false));
-      if (success) {
-        dispatch(setInfo(SET_UI_INFO, {
-          version: data.json.version,
-          lastUpdate: data.json.lastUpdate,
-        }));
-      } else {
-        dispatch(setErrorMessage(SET_UI_ERROR_MESSAGE, data.message));
-      }
+      dispatch(setInfo(SET_UI_INFO, {
+        version: json.version,
+        lastUpdate: json.lastUpdate,
+      }));
+    }).catch(msg => {
+      dispatch(sendingRequest(SENDING_UI_REQUEST, false));
+      dispatch(setErrorMessage(SET_UI_ERROR_MESSAGE, msg));
     });
   };
 }
@@ -32,20 +32,19 @@ export function getApiInfo() {
   return (dispatch) => {
     dispatch(sendingRequest(SENDING_API_REQUEST, true));
 
-    accessAPI(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
+    accessAPINew(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
       method: 'GET',
       endpoint: 'version',
-    }), (success, data) => {
+    })).then(json => {
       dispatch(sendingRequest(SENDING_API_REQUEST, false));
-      if (success) {
-        dispatch(setInfo(SET_API_INFO, {
-          version: data.json.version,
-          lastApiUpdate: data.json.builtAtString,
-          lastDataUpdate: data.json.lastDataUpdate,
-        }));
-      } else {
-        dispatch(setErrorMessage(SET_API_ERROR_MESSAGE, data.message));
-      }
+      dispatch(setInfo(SET_API_INFO, {
+        version: json.version,
+        lastApiUpdate: json.builtAtString,
+        lastDataUpdate: json.lastDataUpdate,
+      }));
+    }).catch(msg => {
+      dispatch(sendingRequest(SENDING_API_REQUEST, false));
+      dispatch(setErrorMessage(SET_API_ERROR_MESSAGE, msg));
     });
   };
 }

--- a/src/actions/InfoActions.js
+++ b/src/actions/InfoActions.js
@@ -1,5 +1,5 @@
 import { SET_UI_INFO, SET_API_INFO, SENDING_UI_REQUEST, SENDING_API_REQUEST, SET_UI_ERROR_MESSAGE, SET_API_ERROR_MESSAGE } from '../constants/InfoConstants';
-import { accessAPINew } from '../utils/accessAPI';
+import accessAPI from '../utils/accessAPI';
 import config from '../config/api-urls';
 
 const { AUTH_URL, REROUTE_URL } = config;
@@ -11,7 +11,7 @@ export function getUiInfo() {
   return (dispatch) => {
     dispatch(sendingRequest(SENDING_UI_REQUEST, true));
 
-    accessAPINew(`${AUTH_URL}/api/info`, 'GET', sessionStorage.accessToken, {}).then(json => {
+    accessAPI(`${AUTH_URL}/api/info`, 'GET', sessionStorage.accessToken, {}).then(json => {
       dispatch(sendingRequest(SENDING_UI_REQUEST, false));
       dispatch(setInfo(SET_UI_INFO, {
         version: json.version,
@@ -31,7 +31,7 @@ export function getApiInfo() {
   return (dispatch) => {
     dispatch(sendingRequest(SENDING_API_REQUEST, true));
 
-    accessAPINew(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
+    accessAPI(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
       method: 'GET',
       endpoint: 'version',
     })).then(json => {

--- a/src/actions/InfoActions.js
+++ b/src/actions/InfoActions.js
@@ -11,8 +11,7 @@ export function getUiInfo() {
   return (dispatch) => {
     dispatch(sendingRequest(SENDING_UI_REQUEST, true));
 
-    accessAPINew(`${AUTH_URL}/api/info`, 'GET', sessionStorage.accessToken, {})
-    .then(json => {
+    accessAPINew(`${AUTH_URL}/api/info`, 'GET', sessionStorage.accessToken, {}).then(json => {
       dispatch(sendingRequest(SENDING_UI_REQUEST, false));
       dispatch(setInfo(SET_UI_INFO, {
         version: json.version,

--- a/src/actions/LoginActions.js
+++ b/src/actions/LoginActions.js
@@ -4,7 +4,6 @@ import { SET_AUTH, SET_CONFETTI, USER_LOGOUT, SENDING_REQUEST, SET_ERROR_MESSAGE
 import * as errorMessages from '../constants/MessageConstants';
 import { getUiInfo, getApiInfo } from '../actions/InfoActions';
 import accessAPI from '../utils/accessAPI';
-import { accessAPINew } from '../utils/accessAPI';
 import config from '../config/api-urls';
 
 const { AUTH_URL } = config;
@@ -28,7 +27,7 @@ export function login(username, password) {
 
     const basicAuth = base64.encode(`${username}:${password}`);
 
-    accessAPINew(`${AUTH_URL}/auth/login`, 'POST', `Basic ${basicAuth}`, JSON.stringify({
+    accessAPI(`${AUTH_URL}/auth/login`, 'POST', `Basic ${basicAuth}`, JSON.stringify({
       username,
     })).then(json => {
       dispatch(sendingRequest(false));
@@ -57,7 +56,7 @@ export function login(username, password) {
  */
 export function checkAuth() {
   return (dispatch) => {
-    accessAPINew(`${AUTH_URL}/auth/checkToken`, 'POST', sessionStorage.accessToken, {}).then(json => {
+    accessAPI(`${AUTH_URL}/auth/checkToken`, 'POST', sessionStorage.accessToken, {}).then(json => {
       dispatch(setAuthState(true));
       if (window.location.pathname === '/') forwardTo('/Home');
       dispatch(getUiInfo());
@@ -81,7 +80,7 @@ export function checkAuth() {
 export function logout() {
   return (dispatch) => {
     dispatch(sendingRequest(true));
-    accessAPINew(`${AUTH_URL}/auth/logout`, 'POST', sessionStorage.accessToken, {}).then(json => {
+    accessAPI(`${AUTH_URL}/auth/logout`, 'POST', sessionStorage.accessToken, {}).then(json => {
       dispatch(setAuthState(false));
       sessionStorage.clear();
       browserHistory.push('/');

--- a/src/components/ErrorModal.js
+++ b/src/components/ErrorModal.js
@@ -2,28 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ModalContainer, ModalDialog } from 'react-modal-dialog';
 
-class ErrorModal extends React.Component {
-  componentWillMount() {
-    window.addEventListener('keydown', this.props.close);
-  }
-  componentWillUnmount() {
-    window.removeEventListener('keydown', this.props.close);
-  }
-  render() {
-    const modal = (this.props.show) ? (<ModalContainer onClose={this.props.close()}>
-      <ModalDialog style={{ width: '80%' }} onClose={this.props.close()}>
-        <h1 style={{ margin: '10px' }}>{this.props.message}</h1>
-        <br />
-        <button className="btn btn--primary" autoFocus onClick={this.props.close()}>Close</button>
-      </ModalDialog>
-    </ModalContainer>) : <div></div>;
-    return (
-      <div>
-        {modal}
-      </div>
-    );
-  }
-}
+const ErrorModal = ({ show, message, close }) => {
+  const modal = (show) ? (<ModalContainer onClose={() => close()}>
+    <ModalDialog style={{ width: '80%' }} onClose={() => close()}>
+      <h1 style={{ margin: '10px' }}>{message}</h1>
+      <br />
+      <button className="btn btn--primary" autoFocus onClick={() => close()}>Close</button>
+    </ModalDialog>
+  </ModalContainer>) : <div></div>;
+  return (
+    <div>
+      {modal}
+    </div>
+  );
+};
 
 ErrorModal.propTypes = {
   show: PropTypes.bool.isRequired,

--- a/src/components/SearchHOC.js
+++ b/src/components/SearchHOC.js
@@ -85,7 +85,7 @@ export default function withSearch(Form, settings, actions, formQuery) {
       document.getElementsByClassName('wrapper')[0].scrollIntoView(false);
       this.child.childTextInput.myInput.focus();
     }
-    closeModal() {
+    closeModal = () => {
       this.setState({ show: false, errorMessage: '' });
       this.focusAndScroll();
     }
@@ -150,7 +150,7 @@ export default function withSearch(Form, settings, actions, formQuery) {
               <ErrorModal
                 show={this.state.show}
                 message={this.state.errorMessage}
-                close={() => this.closeModal}
+                close={this.closeModal}
               />
               <br />
               {this.props.data.results.length !== 0 &&

--- a/src/utils/accessAPI.js
+++ b/src/utils/accessAPI.js
@@ -11,6 +11,28 @@
  * @return {Function}
  *
  */
+export const accessAPINew = (url, method, auth, body) => {
+  return fetch(url, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: auth,
+    },
+    body,
+  }).then((response) => {
+    return new Promise((resolve, reject) => {
+      // We don't need to return the promise below, but it gets rid of an ESLint error
+      // relating to not using a 'break' after each case
+      switch (response.status) {
+        case 200: return resolve(response.json());
+        case 401: return reject('Authentication problem. Please ensure you are logged in.');
+        case 500: return reject('Server error. Please contact your system administrator.');
+        default: return reject(`${response.status} error.`);
+      }
+    });
+  }).catch((err) => new Promise(reject => reject(`Server error: request timed out. ${err}`)));
+};
+
 const accessAPI = (url, method, auth, body, callback) => {
   return fetch(url, {
     method,

--- a/src/utils/accessAPI.js
+++ b/src/utils/accessAPI.js
@@ -11,7 +11,7 @@
  * @return {Function}
  *
  */
-export const accessAPINew = (url, method, auth, body) => {
+const accessAPI = (url, method, auth, body) => {
   return new Promise((resolve, reject) => {
     fetch(url, {
       method,
@@ -32,24 +32,6 @@ export const accessAPINew = (url, method, auth, body) => {
       }
     }).catch((err) => reject(`Server error: request timed out. ${err}`));
   });
-};
-
-const accessAPI = (url, method, auth, body, callback) => {
-  return fetch(url, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: auth,
-    },
-    body,
-  }).then((response) => {
-    switch (response.status) {
-      case 200: return response.json().then((json) => callback(true, { json }));
-      case 401: return callback(false, { message: 'Authentication problem. Please ensure you are logged in.' });
-      case 500: return callback(false, { message: 'Server error. Please contact your system administrator.' });
-      default: return callback(false, { message: `${response.status} error.` });
-    }
-  }).catch((err) => callback(false, { message: `Server error: request timed out. ${err}` }));
 };
 
 export default accessAPI;

--- a/src/utils/accessAPI.js
+++ b/src/utils/accessAPI.js
@@ -26,6 +26,7 @@ const accessAPI = (url, method, auth, body) => {
       switch (response.status) {
         case 200: return resolve(response.json());
         case 400: return reject('Malformed query. Please review your input parameters.');
+        case 404: return reject('Not found. Please review your input parameters.');
         case 401: return reject('Authentication problem. Please ensure you are logged in.');
         case 500: return reject('Server error. Please contact your system administrator.');
         default: return reject(`${response.status} error.`);

--- a/src/utils/accessAPI.js
+++ b/src/utils/accessAPI.js
@@ -12,25 +12,26 @@
  *
  */
 export const accessAPINew = (url, method, auth, body) => {
-  return fetch(url, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: auth,
-    },
-    body,
-  }).then((response) => {
-    return new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
+    fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth,
+      },
+      body,
+    }).then((response) => {
       // We don't need to return the promise below, but it gets rid of an ESLint error
       // relating to not using a 'break' after each case
       switch (response.status) {
         case 200: return resolve(response.json());
+        case 400: return reject('Malformed query. Please review your input parameters.');
         case 401: return reject('Authentication problem. Please ensure you are logged in.');
         case 500: return reject('Server error. Please contact your system administrator.');
         default: return reject(`${response.status} error.`);
       }
-    });
-  }).catch((err) => new Promise(reject => reject(`Server error: request timed out. ${err}`)));
+    }).catch((err) => reject(`Server error: request timed out. ${err}`));
+  });
 };
 
 const accessAPI = (url, method, auth, body, callback) => {

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -37,7 +37,7 @@ class Login extends React.Component {
               <input type="text" placeholder="username" ref={(ref) => (this.usernameInput = ref)} />
               <input type="password" placeholder="password" ref={(ref) => (this.passwordInput = ref)} />
               <Button id="loginButton" size="wide" text="Login" onClick={!this.props.data.currentlySending ? this.onSubmit : null} ariaLabel="Login Button" type="submit" loading={this.props.data.currentlySending} />
-              <ErrorModal show={this.state.show && this.props.data.errorMessage !== ''} message={this.props.data.errorMessage} close={() => this.closeModal} />
+              <ErrorModal show={this.state.show && this.props.data.errorMessage !== ''} message={this.props.data.errorMessage} close={this.closeModal} />
             </form>
           </div>
         </div>


### PR DESCRIPTION
- Rather than having multiple files in `/utils` for each type of API request (info/search/auth), the common functionality of the requests has been encapsulated in `/utils/apiAccess.js`
- Specific JSON keys are no longer dealt with in `/utils/apiAccess.js`, all the JSON is returned and then the calling method (ApiActions/LoginActions/InfoActions) get the relevant bits of JSON