### PR TITLE
Fix/error modal bug

### DIFF
--- a/src/components/ChildRefList.js
+++ b/src/components/ChildRefList.js
@@ -2,10 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LinkButton from '../patterns/LinkButton';
 import Panel from '../patterns/Panel';
-import config from '../config/api-urls';
-import accessAPI from '../utils/accessAPI';
-
-const { REROUTE_URL, API_VERSION, BUSINESS_ENDPOINT } = config;
 
 /**
  * @const ChildRefTable - This is a sub list of the child references of
@@ -16,8 +12,7 @@ const { REROUTE_URL, API_VERSION, BUSINESS_ENDPOINT } = config;
 const ChildRefList = (props) => (
   <div style={{ padding: '20px' }}>
     <LinkButton id="expandRefs" className="mars" text={(props.isLoading) ? 'Loading...' : 'Show reference numbers'} onClick={props.fetchData} loading={false} />
-    <Errorodal show={props.error} message={props.errorMessage} close={props.closeModal} />
-    <Panel id="refsErrorPanel" text={this.state.errorMessage} level="error" show={this.state.error} close={null} marginBottom="1rem" />
+    <Panel id="refsErrorPanel" text={props.errorMessage} level="error" show={props.error} close={null} marginBottom="1rem" />
     {props.finishedLoading &&
       <table>
         <tbody>

--- a/src/components/ChildRefTable.js
+++ b/src/components/ChildRefTable.js
@@ -48,7 +48,7 @@ class ChildRefTable extends React.Component {
         />
         <br />
         <h4>Industry Code [{business.industryCode}]: {description}</h4>
-        <Panel id="refsErrorPanel" text={this.state.errorMessage} level="error" show={this.state.error} close={null} marginBottom="1rem" />
+        <Panel id="refsErrorPanel" text={this.props.errorMessage} level="error" show={this.props.error} close={null} marginBottom="1rem" />
       </div>
     );
   }


### PR DESCRIPTION
Add fixes for prior issues with merge conflicts
- Remove uses of now deprecated `ErrorModal`
- In `ChildRefTable` and `ChildRefList`, use props not `this.state`
