### PR TITLE
Feature/results capped at

### DIFF
--- a/server/apiGateway.js
+++ b/server/apiGateway.js
@@ -68,7 +68,10 @@ app.get('/bi/*', (req, res) => {
     getApiEndpoint(`${urls.API_URL}${url}`)
     .then((response) => {
       logger.info('Returning re-routed GET API request');
-      return res.send(response);
+      if ('x-total-count' in response.headers) {
+        res.setHeader('x-total-count', response.headers['x-total-count']);
+      }
+      return res.send(response.body);
     })
     .catch((error) => {
       logger.error('Error rerouting GET request');
@@ -90,7 +93,7 @@ app.post('/bi/*', (req, res) => {
     postApiEndpoint(`${urls.API_URL}${url}`, postBody)
       .then((response) => {
         logger.info('Returning re-routed POST API request');
-        return res.send(response);
+        return res.send(response.body);
       })
       .catch((error) => {
         logger.error('Error rerouting POST request');
@@ -114,7 +117,8 @@ function getApiEndpoint(url) {
   const options = {
     method: 'GET',
     uri: url,
-    timeout: timeouts.API_GET
+    timeout: timeouts.API_GET,
+    resolveWithFullResponse: true
   };
 
   return rp(options);
@@ -128,6 +132,7 @@ function postApiEndpoint(url, postBody) {
     timeout: timeouts.API_POST,
     headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
     body: JSON.stringify(postBody), // '{"updatedBy":"name","vars":{"ent_name":"name"}}',
+    resolveWithFullResponse: true,
     json: false
   };
 

--- a/server/index.js
+++ b/server/index.js
@@ -77,6 +77,7 @@ if (ENV === 'development') {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
     res.header('Access-Control-Allow-Methods', 'POST, PUT, GET, OPTIONS');
+    res.header('Access-Control-Expose-Headers', 'X-Total-Count');
     next();
   });
 }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -58,7 +58,10 @@ router.post('/api', authMiddleware, (req, res) => {
     getApiEndpoint(`${urls.API_GW}/bi/${endpoint}`, key)
       .then((response) => {
         logger.info('Returning GET response from API Gateway');
-        return res.send(response);
+        if ('x-total-count' in response.headers) {
+          res.setHeader('X-Total-Count', response.headers['x-total-count']);
+        }
+        return res.send(response.body);
       })
       .catch((err) => {
         logger.info('Error in API Gateway for GET request');
@@ -69,7 +72,7 @@ router.post('/api', authMiddleware, (req, res) => {
     postApiEndpoint(`${urls.API_GW}/bi/${endpoint}`, postBody, key)
       .then((response) => {
         logger.info('Returning POST response from API Gateway');
-        return res.send(response);
+        return res.send(response.body);
       })
       .catch((err) => {
         logger.info('Error in API Gateway for POST request');
@@ -87,6 +90,7 @@ function getApiEndpoint(url, apiKey) {
     },
     uri: url,
     timeout: timeouts.API_GET,
+    resolveWithFullResponse: true,
   };
 
   return rp(options);
@@ -104,6 +108,7 @@ function postApiEndpoint(url, postBody, apiKey) {
     },
     body: JSON.stringify(postBody),
     json: false,
+    resolveWithFullResponse: true,
   };
 
   return rp(options);

--- a/src/actions/LoginActions.js
+++ b/src/actions/LoginActions.js
@@ -1,4 +1,3 @@
-// import { browserHistory } from 'react-router';
 import base64 from 'base-64';
 import { SET_AUTH, SET_CONFETTI, USER_LOGOUT, SENDING_REQUEST, SET_ERROR_MESSAGE, SET_USER_DETAILS } from '../constants/LoginConstants';
 import * as errorMessages from '../constants/MessageConstants';
@@ -36,7 +35,8 @@ export const login = (username, password) => (dispatch) => {
   const basicAuth = base64.encode(`${username}:${password}`);
   accessAPI(`${AUTH_URL}/auth/login`, 'POST', `Basic ${basicAuth}`, JSON.stringify({
     username,
-  }), 'login').then(json => {
+  }), 'login').then(response => response.json())
+  .then(json => {
     dispatch(sendingRequest(false));
     dispatch(setAuthState(true));
     dispatch(setConfetti(json.showConfetti));
@@ -59,7 +59,9 @@ export const login = (username, password) => (dispatch) => {
  * accessToken is valid, if not the user will be logged out.
  */
 export const checkAuth = () => (dispatch) => {
-  accessAPI(`${AUTH_URL}/auth/checkToken`, 'POST', sessionStorage.accessToken, {}, 'checkAuth').then(json => {
+  accessAPI(`${AUTH_URL}/auth/checkToken`, 'POST', sessionStorage.accessToken, {}, 'checkAuth')
+  .then(response => response.json())
+  .then(json => {
     dispatch(setAuthState(true));
     if (window.location.pathname === '/') forwardTo('/Home');
     dispatch(setUserState({
@@ -79,7 +81,9 @@ export const checkAuth = () => (dispatch) => {
  */
 export const logout = () => (dispatch) => {
   dispatch(sendingRequest(true));
-  accessAPI(`${AUTH_URL}/auth/logout`, 'POST', sessionStorage.accessToken, {}, 'logout').then(() => {
+  accessAPI(`${AUTH_URL}/auth/logout`, 'POST', sessionStorage.accessToken, {}, 'logout')
+  .then(response => response.json())
+  .then(() => {
     dispatch(setAuthState(false));
     sessionStorage.clear();
     forwardTo('/');

--- a/src/components/ChildSearchHOC.js
+++ b/src/components/ChildSearchHOC.js
@@ -36,7 +36,7 @@ export default function withChildSearch(Content) {
           accessAPI(REROUTE_URL, 'POST', sessionStorage.accessToken, JSON.stringify({
             method: 'GET',
             endpoint: `${API_VERSION}/${BUSINESS_ENDPOINT}/${id}`,
-          }), 'business')
+          }), 'business').then(response => response.json())
           .then(json => this.setState({ ...this.state, data: json, finishedLoading: true, isLoading: false }))
           .catch(() => {
             const errorMessage = 'Error: Unable to get child references.';

--- a/src/components/SearchHOC.js
+++ b/src/components/SearchHOC.js
@@ -75,6 +75,7 @@ export default function withSearch(Content) {
         query={this.props.query}
         errorMessage={this.state.errorMessage}
         results={this.props.results}
+        capped={this.props.capped}
         toHighlight={this.props.toHighlight}
       />
     )
@@ -84,6 +85,7 @@ export default function withSearch(Content) {
     currentlySending: state.apiSearch.currentlySending,
     query: state.apiSearch.query,
     results: state.apiSearch.results,
+    capped: state.apiSearch.capped,
     errorMessage: state.apiSearch.errorMessage,
     toHighlight: state.apiSearch.toHighlight,
   });
@@ -93,6 +95,7 @@ export default function withSearch(Content) {
     currentlySending: PropTypes.bool.isRequired,
     query: PropTypes.object.isRequired,
     results: PropTypes.array.isRequired,
+    capped: PropTypes.string.isRequired,
     toHighlight: PropTypes.string.isRequired,
     errorMessage: PropTypes.string.isRequired,
   };

--- a/src/reducers/apiSearch.js
+++ b/src/reducers/apiSearch.js
@@ -7,6 +7,7 @@ const initialState = {
   formattedQuery: '',
   currentlySending: false,
   errorMessage: '',
+  capped: '',
 };
 
 /**
@@ -23,6 +24,7 @@ const searchReducer = (state = initialState, action) => {
       return Object.assign({}, state, {
         ...state,
         results: action.results,
+        capped: action.capped,
       });
     case SET_TO_HIGHLIGHT:
       return Object.assign({}, state, {

--- a/src/utils/accessAPI.js
+++ b/src/utils/accessAPI.js
@@ -26,7 +26,7 @@ const accessAPI = (url, method, auth, body, requestType) => {
       // We don't need to return the promise below, but it gets rid of an ESLint error
       // relating to not using a 'break' after each case
       switch (response.status) {
-        case 200: return resolve(response.json());
+        case 200: return resolve(response);
         case 400: return reject('Malformed query. Please review your input parameters.');
         case 404: return reject('Not found. Please review your input parameters.');
         case 401: return reject('Authentication problem. Please ensure you are logged in.');

--- a/src/utils/helperMethods.js
+++ b/src/utils/helperMethods.js
@@ -11,6 +11,18 @@ const maxSize = (...args) => args.reduce((a, b) => (b.length > a ? b.length : a)
 
 
 /**
+ * @const numberWithCommas - Make a number more human readable
+ *
+ * Source: https://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
+ *
+ * @param {Number} x - The number to add commas to
+ *
+ * @return {String}
+ */
+const numberWithCommas = (x) => x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+
+/**
  * @const formatData - Format references from a Business object into a format
  * that react-table can handle.
  *
@@ -139,5 +151,5 @@ const anyKeyEmpty = (obj) => Object.keys(obj).map(key => (obj[key] === '')).redu
 
 export {
   formatData, handleFormChange, formSelectJson, getHighlightedText,
-  everyKeyMatches, anyKeyEmpty, maxSize,
+  everyKeyMatches, anyKeyEmpty, maxSize, numberWithCommas,
 };

--- a/src/views/Results.js
+++ b/src/views/Results.js
@@ -5,6 +5,7 @@ import Panel from '../patterns/Panel';
 import ResultsTable from '../components/ResultsTable';
 import ResultsList from '../components/ResultsList';
 import ResultsSearchForm from '../components/ResultsSearchForm';
+import { numberWithCommas } from '../utils/helperMethods';
 import { downloadCSV, downloadJSON } from '../utils/export';
 
 /**
@@ -12,6 +13,9 @@ import { downloadCSV, downloadJSON } from '../utils/export';
  * props that Results require (for the search + form). This page is shown once a search
  * has been made (or the user goes directly to /Results). In addition to showing the
  * search results, it shows an edit search form.
+ *
+ * @todo - The Panel for displaying how many results have been capped should be created
+ * as a component
  */
 class Results extends React.Component {
   constructor(props) {
@@ -22,15 +26,15 @@ class Results extends React.Component {
     };
   }
   componentDidMount = () => this.scrollToResults();
-  scrollToResults = () => document.getElementById('homeTitle').scrollIntoView({ block: 'start', behavior: 'smooth' });
   onSubmit = (e) => {
     e.preventDefault();
     // We need to pass e through so the parent e.preventDefault() will work
     this.props.onSubmit(e);
     this.scrollToResults();
   }
+  scrollToResults = () => document.getElementById('homeTitle').scrollIntoView({ block: 'start', behavior: 'smooth' });
   render() {
-    const capped = (<div style={{ marginLeft: '5px' }} className="badge badge--amber">CAPPED</div>);
+    const capped = (<div style={{ marginLeft: '10px', display: 'inline-block' }} className="badge badge--amber">CAPPED</div>);
     const numResults = this.props.results.length;
     return (
       <section>
@@ -63,7 +67,10 @@ class Results extends React.Component {
                   </div>
                 }
                 {!this.props.currentlySending &&
-                  <p className="mars">We&apos;ve found {numResults} {(numResults > 1 || numResults === 0) ? 'businesses' : 'business'} {(numResults === 10000) ? capped : null}</p>
+                  <div style={{ display: 'inline' }}>
+                    <p style={{ display: 'inline' }} className="mars">We&apos;ve found {numberWithCommas(numResults)} {(numResults > 1 || numResults === 0) ? 'businesses' : 'business'}</p>
+                    {(numResults === 10000) ? capped : null}
+                  </div>
                 }
                 <div className="key-line"></div>
                 <Panel id="searchErrorPanel" text={this.props.errorMessage} level="error" show={this.props.showError} close={this.props.closeModal} marginBottom="1rem" />
@@ -79,6 +86,19 @@ class Results extends React.Component {
                     showPagination
                     defaultPageSize={10}
                   />
+                }
+                {(!this.props.currentlySending && this.props.results.length === 10000) &&
+                  <div>
+                    <br />
+                    <div className="panel panel--warn">
+                      <div className="panel__header">
+                        <div className="venus">Warning</div>
+                      </div>
+                      <div className="panel__body">
+                        <div>Your results have been capped at 10,000, from a total of {numberWithCommas(this.props.capped)} results</div>
+                      </div>
+                    </div>
+                  </div>
                 }
               </div>
             </div>
@@ -102,6 +122,7 @@ Results.propTypes = {
   currentlySending: PropTypes.bool.isRequired,
   query: PropTypes.object.isRequired,
   results: PropTypes.array.isRequired,
+  capped: PropTypes.string.isRequired,
   showError: PropTypes.bool.isRequired,
   errorMessage: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/test/utils-spec/helperMethods-test.js
+++ b/test/utils-spec/helperMethods-test.js
@@ -1,6 +1,6 @@
 import {
   maxSize, formatData, everyKeyMatches, handleFormChange,
-  formSelectJson, anyKeyEmpty
+  formSelectJson, anyKeyEmpty, numberWithCommas
 } from '../../src/utils/helperMethods';
 
 describe("maxSize", () => {
@@ -167,5 +167,27 @@ describe("anyKeyEmpty", () => {
   it("returns false if no keys are empty", () => {
     const result = anyKeyEmpty({ a: '1', b: '2', c: '3' });
     expect(result).toBe(false);
+  });
+});
+
+describe("numberWithCommas", () => {
+  it("returns a small number with no commas", () => {
+    const result = numberWithCommas(100);
+    expect(result).toBe('100');
+  });
+
+  it("returns a large number with commas", () => {
+    const result = numberWithCommas(100000);
+    expect(result).toBe('100,000');
+  });
+
+  it("returns a very large number with commas", () => {
+    const result = numberWithCommas(100000000);
+    expect(result).toBe('100,000,000');
+  });
+
+  it("handles being passed a string", () => {
+    const result = numberWithCommas('Error');
+    expect(result).toBe('Error');
   });
 });


### PR DESCRIPTION
- Add a `Panel` that is displayed at the bottom of the results page, with details of how many results have been capped
- Add code to handle the returning of the `X-Total-Count` header from within `apiGateway.js` and `/routes/api.js`
- Add code for handling the setting of `capped` for the redux related reducer/actions
- Add handling of return of response promise, rather than json promise from `apiAccess.js`
- Add unit tests for additional helper method