### PR TITLE
Fix/private routes

### DIFF
--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types';
 import { Route, Redirect, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 
+/**
+ * @const PrivateRoute - A component that will display a given child component
+ * if the user is logged in, otherwise the user will be redirected back to
+ * the login page.
+ */
 const PrivateRoute = ({ component: Component, loggedIn, ...rest }) => {
   return (
     <Route

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route, Redirect, withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+const PrivateRoute = ({ component: Component, loggedIn, ...rest }) => {
+  return (
+    <Route
+      {...rest}
+      render={(props) => (loggedIn
+        ? <Component {...props} />
+        : <Redirect to={{ pathname: '/', state: { from: props.location } }} />)}
+    />
+  );
+};
+
+PrivateRoute.propTypes = {
+  location: PropTypes.object.isRequired,
+  loggedIn: PropTypes.bool.isRequired,
+  component: PropTypes.func.isRequired,
+};
+
+const select = (state) => ({ loggedIn: state.login.loggedIn });
+
+export default withRouter(connect(select)(PrivateRoute));
+

--- a/src/routes.js
+++ b/src/routes.js
@@ -22,12 +22,6 @@ const store = createStoreWithMiddleware(
   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
 );
 
-const a = () => {
-  const loggedIn = store.getState().login.loggedIn;
-  console.log('calling a: ', loggedIn);
-  return loggedIn;
-};
-
 const Routes = () => (
   <Provider store={store}>
     <Router history={history}>
@@ -35,10 +29,8 @@ const Routes = () => (
         <Template>
           <Switch>
             <Route exact path="/" component={Login} />
-            {/* <PrivateRoute authed={this.state.authed} path='/dashboard' component={Dashboard} /> */}
-            {/* <Route exact path="/Home" component={withSearch(Home)} /> */}
-            <PrivateRoute authed={a} exact path="/Home" component={withSearch(Home)} />
-            <Route exact path="/Results" component={withSearch(Results)} />
+            <PrivateRoute exact path="/Home" component={withSearch(Home)} />
+            <PrivateRoute exact path="/Results" component={withSearch(Results)} />
             <Route component={NotFound} />
           </Switch>
         </Template>

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,6 +11,7 @@ import NotFound from './views/NotFound';
 import Template from './templates/Template';
 import Login from './views/Login';
 import withSearch from './components/SearchHOC';
+import PrivateRoute from './components/PrivateRoute';
 
 // Create the Redux store with the redux-thunk middleware (for async actions)
 const createStoreWithMiddleware = applyMiddleware(thunk)(createStore);
@@ -21,6 +22,12 @@ const store = createStoreWithMiddleware(
   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
 );
 
+const a = () => {
+  const loggedIn = store.getState().login.loggedIn;
+  console.log('calling a: ', loggedIn);
+  return loggedIn;
+};
+
 const Routes = () => (
   <Provider store={store}>
     <Router history={history}>
@@ -28,7 +35,9 @@ const Routes = () => (
         <Template>
           <Switch>
             <Route exact path="/" component={Login} />
-            <Route exact path="/Home" component={withSearch(Home)} />
+            {/* <PrivateRoute authed={this.state.authed} path='/dashboard' component={Dashboard} /> */}
+            {/* <Route exact path="/Home" component={withSearch(Home)} /> */}
+            <PrivateRoute authed={a} exact path="/Home" component={withSearch(Home)} />
             <Route exact path="/Results" component={withSearch(Results)} />
             <Route component={NotFound} />
           </Switch>

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import history from '../history';
 import { login, resetLoginErrorMsg } from '../actions/LoginActions';
 import Button from '../patterns/Button';
 import LinkButton from '../patterns/LinkButton';
@@ -18,6 +19,10 @@ class Login extends React.Component {
       showForgotPass: false,
       errorMessage: '',
     };
+  }
+  componentDidMount = () => {
+    // We don't want to allow the user to access the login page if they're already logged in
+    if (this.props.loggedIn) history.push('/Home');
   }
   onSubmit = (evt) => {
     evt.preventDefault(); // Stop the page from refreshing
@@ -63,11 +68,13 @@ Login.propTypes = {
   dispatch: PropTypes.func.isRequired,
   currentlySending: PropTypes.bool.isRequired,
   errorMessage: PropTypes.string.isRequired,
+  loggedIn: PropTypes.bool.isRequired,
 };
 
 const select = (state) => ({
   currentlySending: state.login.currentlySending,
   errorMessage: state.login.errorMessage,
+  loggedIn: state.login.loggedIn,
 });
 
 export default connect(select)(Login);


### PR DESCRIPTION
This PR fixes a bug where a user can navigate to the `/Home` page (or any other page) without being logged in (although a search wouldn't have worked as the token wouldn't have been present).

A new `<PrivateRoute>` component has been added to prevent users from navigating to routes that require authentication. The `<Login>` component has also been modified to prevent a user from going back to the login page without having actually logged out.