### PR TITLE
Fix not all alphanumeric search fields being transformed to upper case

### DIFF
--- a/src/utils/helperMethods.js
+++ b/src/utils/helperMethods.js
@@ -117,7 +117,12 @@ const handleFormChange = (form, id, value) => {
   } else if (Array.isArray(value) && value.length === 0) {
     // Multiple select input will return an empty array if nothing is selected
     delete formCopy[id];
-  } else if (id === 'BusinessName' || id === 'PostCode') {
+  } else if (id === 'BusinessName' || id === 'PostCode'
+      || id === 'CompanyNo'
+      || id === 'Id'
+      || id === 'VatRefs'
+      || id === 'PayeRefs'
+  ) {
     formCopy[id] = value.toUpperCase();
   } else {
     formCopy[id] = value;

--- a/test/utils-spec/helperMethods-test.js
+++ b/test/utils-spec/helperMethods-test.js
@@ -137,10 +137,42 @@ describe("handleFormChange", () => {
     expect(JSON.stringify(result)).toBe(JSON.stringify(expected));
   });
 
-  it("transforms businessName to upper case", () => {
+  it("transforms PostCode to upper case", () => {
     const result = handleFormChange({ PostCode: 'a' }, 'PostCode', 'a');
     const expected = {
       PostCode: 'A',
+    };
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expected));
+  });
+
+  it("transforms CompanyNo to upper case", () => {
+    const result = handleFormChange({ CompanyNo: 'a' }, 'CompanyNo', 'a');
+    const expected = {
+        CompanyNo: 'A',
+    };
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expected));
+  });
+
+  it("transforms Id to upper case", () => {
+    const result = handleFormChange({ Id: 'a' }, 'Id', 'a');
+    const expected = {
+        Id: 'A',
+    };
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expected));
+  });
+
+  it("transforms VatRefs to upper case", () => {
+    const result = handleFormChange({ VatRefs: 'a' }, 'VatRefs', 'a');
+    const expected = {
+        VatRefs: 'A',
+    };
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expected));
+  });
+
+  it("transforms PayeRefs to upper case", () => {
+    const result = handleFormChange({ PayeRefs: 'a' }, 'PayeRefs', 'a');
+    const expected = {
+        PayeRefs: 'A',
     };
     expect(JSON.stringify(result)).toBe(JSON.stringify(expected));
   });


### PR DESCRIPTION
Only Postcode and Business name were being transformed to uppoer case
whereas the other 4 search fields were not. This creates an inconsistent
user experience.

This fix will transform all alphanumeric fields to upper case
automatically

Task: REG-532